### PR TITLE
Clearing secureSocket collection

### DIFF
--- a/src/factories/createInternalHttpTerminator.js
+++ b/src/factories/createInternalHttpTerminator.js
@@ -61,7 +61,11 @@ export default (configurationInput: HttpTerminatorConfigurationInputType): Inter
   const destroySocket = (socket) => {
     socket.destroy();
 
-    sockets.delete(socket);
+    if (socket.server instanceof http.Server) {
+      sockets.delete(socket);
+    } else {
+      secureSockets.delete(socket);
+    }
   };
 
   const terminate = async () => {
@@ -124,6 +128,14 @@ export default (configurationInput: HttpTerminatorConfigurationInputType): Inter
       await delay(configuration.gracefulTerminationTimeout);
 
       for (const socket of sockets) {
+        destroySocket(socket);
+      }
+    }
+
+    if (secureSockets.size) {
+      await delay(configuration.gracefulTerminationTimeout);
+
+      for (const socket of secureSockets) {
         destroySocket(socket);
       }
     }


### PR DESCRIPTION
Clearing any remaining sockets in secureSocket collection after the grace period. 
Also added logic to delete a socket from the right collection in destroySocket.