### PR TITLE
README.md: make express example more typescript-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ import {
 
 const app = express();
 
-const server = app.listen();
+const httpserver = app.listen();
 
 const httpTerminator = createHttpTerminator({
-  server,
+  server: httpserver,
 });
 
 await httpTerminator.terminate();


### PR DESCRIPTION
When the object returned by `app.listen()` is not called `server` but e.g. `httpserver` then

```
const httpTerminator = createHttpTerminator({
  httpserver,
});
```

will not compile, but

```
const httpTerminator = createHttpTerminator({
  server: httpserver,
});
```

does.