### PR TITLE
Fix: Require a minimum version of @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "description": "Gracefully terminates HTTP(S) server.",
   "devDependencies": {
+    "@types/node": "^16.0.0",
     "agentkeepalive": "^4.1.4",
     "ava": "^3.15.0",
     "babel-plugin-istanbul": "^6.0.0",


### PR DESCRIPTION
Requires a minimum version of `@types/node` as part of the `package.json` file. 
There's a typescript compilation issue when referencing `node:stream` when the local version of `@types/node` is `<16.0.0`.

This error can happen when installing `http-terminator` on an existing project with a `package-lock.json` that references an older version of `@types/node`.

I believe this also resolves  issue #32.