### PR TITLE
fix: use @types/node 10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "description": "Gracefully terminates HTTP(S) server.",
   "devDependencies": {
-    "@types/node": "^16.0.0",
+    "@types/node": "^10.0.0",
     "agentkeepalive": "^4.1.4",
     "ava": "^3.15.0",
     "babel-plugin-istanbul": "^6.0.0",

--- a/src/factories/createInternalHttpTerminator.ts
+++ b/src/factories/createInternalHttpTerminator.ts
@@ -4,7 +4,7 @@ import http from 'http';
 import waitFor from 'p-wait-for';
 import type {
   Duplex,
-} from 'node:stream';
+} from 'stream';
 import Logger from '../Logger';
 import type {
   HttpTerminatorConfigurationInput,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ import type {
 } from 'https';
 import type {
   Duplex,
-} from 'node:stream';
+} from 'stream';
 import type {
   Merge,
 } from 'type-fest';


### PR DESCRIPTION
## Summary
Use @types/node v10.0.0 to match `"engines": { "node": ">=10" }` declared in `package.json`.

## Motivation
Some projects use `@types/node` 10/12 which don't support `node:` prefixed modules. For those projects TS compilation might fail when `tsconfig.json` has `skipLibCheck: false`.