### PR TITLE
Fix Default Timeout Value as per Docs

### DIFF
--- a/src/factories/createInternalHttpTerminator.ts
+++ b/src/factories/createInternalHttpTerminator.ts
@@ -18,7 +18,7 @@ const log = Logger.child({
 });
 
 const configurationDefaults = {
-  gracefulTerminationTimeout: 1_000,
+  gracefulTerminationTimeout: 5000,
 };
 
 export const createInternalHttpTerminator = (

--- a/src/factories/createInternalHttpTerminator.ts
+++ b/src/factories/createInternalHttpTerminator.ts
@@ -18,7 +18,7 @@ const log = Logger.child({
 });
 
 const configurationDefaults = {
-  gracefulTerminationTimeout: 5000,
+  gracefulTerminationTimeout: 5_000,
 };
 
 export const createInternalHttpTerminator = (


### PR DESCRIPTION
The documentation says that the default gracefulShutdownTimeout is 5000ms but actually it is 1000ms. Changed the config to have 5000ms, the value specified in the docs. 