### PR TITLE
Update gracefulTerminationTimeout value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import {
 } from 'http-terminator';
 
 /**
- * @property gracefulTerminationTimeout Number of milliseconds to allow for the active sockets to complete serving the response (default: 5000).
+ * @property gracefulTerminationTimeout Number of milliseconds to allow for the active sockets to complete serving the response (default: 1000).
  * @property server Instance of http.Server.
  */
 type HttpTerminatorConfigurationInputType = {|


### PR DESCRIPTION
`configurationDefaults.gracefulTerminationTimeout` is 1000, but the readme says 5000.