### PR TITLE
feat: add `Http2Server`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type {
 } from 'http';
 import type {
   Http2SecureServer,
+  Http2Server,
 } from 'http2';
 import type {
   Server as HttpsServer,
@@ -20,7 +21,7 @@ import type {
  */
 export type HttpTerminatorConfigurationInput = {
   readonly gracefulTerminationTimeout?: number,
-  readonly server: Http2SecureServer | HttpServer | HttpsServer,
+  readonly server: Http2Server | Http2SecureServer | HttpServer | HttpsServer,
 };
 
 /**


### PR DESCRIPTION
Adds support of `Http2Server`, which is the insecure version of the `Http2SecureServer` added in https://github.com/gajus/http-terminator/commit/aabca4751552e983f8a59ba896b7fb58ce3b4087

Resolves #45 

